### PR TITLE
Add setting contents on mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sh-quill",
-  "version": "0.0.67",
+  "version": "0.0.70",
   "description": "The Quill rich-text editor as a React component. Based on react-quill",
   "license": "MIT",
   "main": "./bin/sh-quill.js",

--- a/src/component.js
+++ b/src/component.js
@@ -121,7 +121,11 @@ let QuillComponent = React.createClass({
             fontOptions[i].style.fontFamily = fontOptions[i].dataset.value;
         }
 
-        this.setState({ editor:editor });
+        this.setState({ editor:editor }, () => {
+            if (this.props.value) {
+                this.setEditorContents(editor, this.props.value);
+            }
+        });
     },
 
     componentWillUnmount: function() {


### PR DESCRIPTION
There appears to be some timing when components are mounting and receiving new props, where the editor renders the old props even though it has the new one.